### PR TITLE
Make themes_on_rails thread-safe by not modifying the controller class on every request

### DIFF
--- a/lib/themes_on_rails/action_controller.rb
+++ b/lib/themes_on_rails/action_controller.rb
@@ -7,13 +7,16 @@ module ThemesOnRails
         filter_method = before_filter_method(options)
         options       = options.slice(:only, :except)
 
+        # set layout
+        controller_class.class_eval do
+          define_method :layout_from_theme do
+            ThemesOnRails::ActionController.new(self, theme).theme_name
+          end
+          private :layout_from_theme
+          layout :layout_from_theme, options
+        end
+
         controller_class.send(filter_method, options) do |controller|
-
-          # set layout
-          controller_class.layout Proc.new { |controller|
-            ThemesOnRails::ActionController.new(controller, theme).theme_name
-          }, options
-
           # initialize
           theme_instance = ThemesOnRails::ActionController.new(controller, theme)
 


### PR DESCRIPTION
This should not have any difference on MRI since it as a GIL, but would impact parallelised implementations like jRuby and Rubinius.

Furthermore, this helps with inherited layouts, since if a layout is defined via a Proc, it does not allow overriding by subclasses.

Makes working with gems like [High Voltage](/thoughtbot/high_voltage) possible since they also override `layout`.
