### PR TITLE
Implements theme caching in production.

### DIFF
--- a/lib/themes_on_rails.rb
+++ b/lib/themes_on_rails.rb
@@ -3,8 +3,9 @@ require 'themes_on_rails/engine'
 require 'active_support/concern'
 
 module ThemesOnRails
-  autoload :ActionController,    'themes_on_rails/action_controller'
-  autoload :ControllerAdditions, 'themes_on_rails/controller_additions'
+  autoload :ActionController,        'themes_on_rails/action_controller'
+  autoload :ControllerAdditions,     'themes_on_rails/controller_additions'
+  autoload :FileSystemResolverCache, 'themes_on_rails/file_system_resolver_cache'
 
   def self.all
     Dir.glob("app/themes/*").select { |fn| !fn.start_with?('.') && File.directory?(fn) }.map { |fn| fn.split('/').last }

--- a/lib/themes_on_rails/engine.rb
+++ b/lib/themes_on_rails/engine.rb
@@ -8,6 +8,12 @@ module ThemesOnRails
       end
     end
 
+    initializer 'themes_on_rails.action_view' do
+      ActiveSupport.on_load :action_view do
+        ActionView::OptimizedFileSystemResolver.include(ThemesOnRails::FileSystemResolverCache)
+      end
+    end
+
     initializer 'themes_on_rails.load_locales' do |app|
       app.config.i18n.load_path += Dir[Rails.root.join('app/themes/*', 'locales', '**', '*.yml').to_s]
     end

--- a/lib/themes_on_rails/file_system_resolver_cache.rb
+++ b/lib/themes_on_rails/file_system_resolver_cache.rb
@@ -1,0 +1,13 @@
+module ThemesOnRails::FileSystemResolverCache
+  extend ActiveSupport::Concern
+
+  included do
+    @cache = Hash.new
+  end
+
+  module ClassMethods
+    def new(path, *args)
+      @cache[path] ||= super
+    end
+  end
+end


### PR DESCRIPTION
Cached templates are kept together with the template resolver in ActionView. Creating a new template resolver at every request would therefore result in templates not being cached.

Fixes #29
